### PR TITLE
Exit code on --fail flage usage is 1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,5 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Should exit with code 1
         run: |
-          docker run --rm curl:local --fail https://httpbin.org/status/401
-          exit_code=$?
-          [ $exit_code -eq 1 ] && echo "all is ok" || ( echo "Wrong exit code: $exit_code"; exit 1 )
+          docker run --rm curl:local --fail "https://httpbin.org/status/401"; exit_code=$?
+          test $exit_code -eq 1 && echo "all is ok" || ( echo "Wrong exit code: $exit_code"; exit 1 )

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,5 +87,5 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Should exit with code 1
         run: |
-          docker run --rm curl:local --fail "https://httpbin.org/status/401"; exit_code=$?
-          test $exit_code -eq 1 && echo "all is ok" || ( echo "Wrong exit code: $exit_code"; exit 1 )
+          docker run --rm curl:local --fail "https://httpbin.org/status/401" || ec=$?
+          test $ec -eq 1 && echo "all is ok (code = $ec)" || ( echo "Wrong exit code: $ec"; exit 1 )

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,3 +84,9 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Try to run (example.com)
         run: docker run --rm curl:local --fail http://example.com/
+
+      - name: Should exit with code 1
+        run: |
+          docker run --rm curl:local --fail https://httpbin.org/status/401
+          exit_code=$?
+          [ $exit_code -eq 1 ] && echo "all is ok" || ( echo "Wrong exit code: $exit_code"; exit 1 )

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ RUN set -x \
 # change working directory to the directory with curl sources
 WORKDIR "/tmp/curl-${CURL_VERSION}"
 
-# temp patch so it will build statically https://github.com/curl/curl/pull/7476
-COPY ./static.patch .
-RUN patch -p1 < ./static.patch
+# apply patches to the source code
+COPY ./patches ./patches
+RUN for f in ./patches/*.patch; do patch -p1 < "$f"; done
 
 ENV CC="clang" \
     LDFLAGS="-static" \

--- a/patches/fail-exit-code.patch
+++ b/patches/fail-exit-code.patch
@@ -1,0 +1,16 @@
+diff --git a/src/tool_operate.c b/src/tool_operate.c
+index e6ca575..4f3e65f 100644
+--- a/src/tool_operate.c
++++ b/src/tool_operate.c
+@@ -622,6 +622,11 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
+   free(per->outfile);
+   free(per->uploadfile);
+
++  /* return exit code 1 when flag --fail is used */
++  if (config->failonerror && (CURLE_HTTP_RETURNED_ERROR == result)) {
++    result = CURLE_UNSUPPORTED_PROTOCOL;
++  }
++
+   return result;
+ }
+

--- a/patches/static.patch
+++ b/patches/static.patch
@@ -1,8 +1,8 @@
 diff --git a/src/Makefile.am b/src/Makefile.am
-index 734373187..37e3a1564 100644
+index 7343731..52ff4cd 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -66,6 +66,9 @@ else
+@@ -66,6 +66,10 @@ else
  curl_LDADD = $(top_builddir)/lib/libcurl.la @NSS_LIBS@ @SSL_LIBS@ @ZLIB_LIBS@ @CURL_NETWORK_AND_TIME_LIBS@
  endif
 

--- a/patches/static.patch
+++ b/patches/static.patch
@@ -6,6 +6,7 @@ index 734373187..37e3a1564 100644
  curl_LDADD = $(top_builddir)/lib/libcurl.la @NSS_LIBS@ @SSL_LIBS@ @ZLIB_LIBS@ @CURL_NETWORK_AND_TIME_LIBS@
  endif
 
++# https://github.com/curl/curl/pull/7476
 +curl_LDFLAGS = $(curl_LDFLAGS)
 +curl_CPPFLAGS = $(AM_CPPFLAGS)
 +


### PR DESCRIPTION
## Description

When flag `--fail` is used - the exit code is 1 (instead of 22).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
